### PR TITLE
Fixed #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,11 @@
+# v0.1.5
+* Fixed Rails 6 deprecation warning: "Single arity template handlers are deprecated. Template handlers must now accept two parameters, the view object and the source for the view object."
+
+# v0.1.4
+* Update constant name
+
+# v0.1.2
+* Fix version load
+
 # v0.1.0
 * Initial release

--- a/lib/kramdown-rails/inject.rb
+++ b/lib/kramdown-rails/inject.rb
@@ -2,7 +2,7 @@ require 'kramdown'
 
 module Kramdown
   module Converter
-    module Html
+    class Html
 
       include ActionView::Helpers::AssetTagHelper
 
@@ -27,8 +27,8 @@ module KramdownRails
         Thread.current[:erb_template] ||= ActionView::Template.registered_template_handler(:erb)
       end
 
-      def call(template)
-        compiled_template = erb.call(template)
+      def call(template, source)
+        compiled_template = erb.call(template, source)
         "Kramdown::Document.new(begin;#{compiled_template};end).to_html.html_safe"
       end
 

--- a/lib/kramdown-rails/version.rb
+++ b/lib/kramdown-rails/version.rb
@@ -1,3 +1,3 @@
 module KramdownRails
-  VERSION = Gem::Version.new('0.1.2')
+  VERSION = Gem::Version.new('0.1.5')
 end


### PR DESCRIPTION
Fixes #1 

The source code in the repo seems to be outdated, as the gem that I had installed was on v0.1.4 and had "updated the constant name" (see changelog for 0.1.2 and 0.1.4).

This PR includes these updates as well.